### PR TITLE
Add option to not inject REPLICAS env to containers

### DIFF
--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
@@ -51,6 +51,10 @@ type QuarksStatefulSetSpec struct {
 	// Periodic probe for active/passive containers
 	// Only an active container will process request from a service
 	ActivePassiveProbes map[string]corev1.Probe `json:"activePassiveProbes,omitempty"`
+
+	// Determines whether the REPLICAS env var should be injected into pod containers
+	// By default, true.
+	InjectReplicasEnv *bool `json:"injectReplicasEnv,omitempty"`
 }
 
 // QuarksStatefulSetStatus defines the observed state of QuarksStatefulSet

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/zz_generated.deepcopy.go
@@ -91,6 +91,11 @@ func (in *QuarksStatefulSetSpec) DeepCopyInto(out *QuarksStatefulSetSpec) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
+	if in.InjectReplicasEnv != nil {
+		in, out := &in.InjectReplicasEnv, &out.InjectReplicasEnv
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Some workloads don't need `REPLICAS`.
This env is special in that it makes all pods restart when it's changed.
Currently, the default remains that it should be injected.