### PR TITLE
Don't include a version annotation in pods

### DIFF
--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -257,7 +257,6 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 	labels[qstsv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
 	labels[qstsv1a1.LabelQStsName] = statefulSetNamePrefix
 
-	annotations[qstsv1a1.AnnotationVersion] = strconv.Itoa(version)
 	annotations[statefulset.AnnotationCanaryRolloutEnabled] = "true"
 
 	// Set updated properties
@@ -268,6 +267,8 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 	statefulSet.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: labels,
 	}
+
+	annotations[qstsv1a1.AnnotationVersion] = strconv.Itoa(version)
 	statefulSet.SetAnnotations(util.UnionMaps(statefulSet.GetAnnotations(), annotations))
 
 	r.injectContainerEnv(&statefulSet.Spec.Template.Spec, zoneIndex, zoneName, qStatefulSet.Spec.Template.Spec.Replicas, qStatefulSet.Spec.InjectReplicasEnv)

--- a/pkg/kube/controllers/statefulset/statefulset_rollout_controller.go
+++ b/pkg/kube/controllers/statefulset/statefulset_rollout_controller.go
@@ -45,7 +45,7 @@ func AddStatefulSetRollout(ctx context.Context, config *config.Config, mgr manag
 			if CheckUpdate(e) {
 				ctxlog.NewPredicateEvent(e.ObjectNew).Debug(
 					ctx, e.MetaNew, "StatefulSet",
-					fmt.Sprintf("Update predicate passed for '%s/%s'", e.MetaNew.GetNamespace(), e.MetaNew.GetName()),
+					fmt.Sprintf("Update predicate passed for '%s/%s' for statefulset rollout", e.MetaNew.GetNamespace(), e.MetaNew.GetName()),
 				)
 				return true
 			}


### PR DESCRIPTION
It makes everything restart on updates, even when not necessary.
