### PR TITLE
Revert 'Add instance id as label'

### DIFF
--- a/deploy/helm/quarks-statefulset/Chart.yaml
+++ b/deploy/helm/quarks-statefulset/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: quarks-statefulset
-version: x.x.x
-appVersion: x.x.x
+version: 0.0.0
+appVersion: 0.0.0
 description: A Helm chart for quarks-statefulset
 home: https://github.com/cloudfoundry-incubator/quarks-statefulset
 icon: https://cloudfoundry-incubator.github.io/quarks-helm/logo.png

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/types.go
@@ -34,9 +34,6 @@ var (
 	// LabelStartupOrdinal is the index of a pod in startup order
 	LabelStartupOrdinal = fmt.Sprintf("%s/startup-ordinal", apis.GroupName)
 
-	// LabelInstance is the instance.id/spec.id
-	LabelInstance = fmt.Sprintf("%s/spec-index", apis.GroupName)
-
 	// LabelQStsName is the name of the QuarksStatefulSet owns this resource
 	LabelQStsName = fmt.Sprintf("%s/quarks-statefulset-name", apis.GroupName)
 	// LabelStsName is the name of the QuarksStatefulSet owns this resource

--- a/pkg/kube/controllers/quarksstatefulset/pod_mutator.go
+++ b/pkg/kube/controllers/quarksstatefulset/pod_mutator.go
@@ -79,15 +79,8 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 func setPodOrdinal(pod *corev1.Pod, podLabels map[string]string) {
 	podOrdinal := names.OrdinalFromPodName(pod.GetName())
 
-	azIndex, err := strconv.Atoi(podLabels[qstsv1a1.LabelAZIndex])
-	if err != nil {
-		azIndex = 0
-	}
-	specIndex := names.SpecIndex(azIndex, podOrdinal)
-
 	if podOrdinal != -1 {
 		podLabels[qstsv1a1.LabelPodOrdinal] = strconv.Itoa(podOrdinal)
-		podLabels[qstsv1a1.LabelInstance] = strconv.Itoa(specIndex)
 		pod.SetLabels(podLabels)
 	}
 }

--- a/pkg/kube/controllers/quarksstatefulset/pod_mutator_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/pod_mutator_test.go
@@ -144,10 +144,9 @@ var _ = Describe("Add labels to qsts pods", func() {
 			It("sets ordinal labels correct", func() {
 				Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-				Expect(response.Patches).To(HaveLen(3))
+				Expect(response.Patches).To(HaveLen(2))
 				patches := jsonPatches(response.Patches)
 				Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "0")))
-				Expect(patches).To(ContainElement(addLabelPatch("spec-index", "0")))
 				Expect(patches).To(ContainElement(addLabelPatch("startup-ordinal", "0")))
 
 				Expect(response.AdmissionResponse.Allowed).To(BeTrue())
@@ -164,10 +163,9 @@ var _ = Describe("Add labels to qsts pods", func() {
 			It("sets ordinal labels correct", func() {
 				Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-				Expect(response.Patches).To(HaveLen(3))
+				Expect(response.Patches).To(HaveLen(2))
 				patches := jsonPatches(response.Patches)
 				Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "0")))
-				Expect(patches).To(ContainElement(addLabelPatch("spec-index", "0")))
 				Expect(patches).To(ContainElement(addLabelPatch("startup-ordinal", "0")))
 
 				Expect(response.AdmissionResponse.Allowed).To(BeTrue())
@@ -215,10 +213,9 @@ var _ = Describe("Add labels to qsts pods", func() {
 			It("sets ordinal labels are correct", func() {
 				Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-				Expect(response.Patches).To(HaveLen(3))
+				Expect(response.Patches).To(HaveLen(2))
 				patches := jsonPatches(response.Patches)
 				Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "1")))
-				Expect(patches).To(ContainElement(addLabelPatch("spec-index", "1")))
 				Expect(patches).To(ContainElement(addLabelPatch("startup-ordinal", "1")))
 
 				Expect(response.AdmissionResponse.Allowed).To(BeTrue())
@@ -237,10 +234,9 @@ var _ = Describe("Add labels to qsts pods", func() {
 				It("sets ordinal labels correctly", func() {
 					Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-					Expect(response.Patches).To(HaveLen(3))
+					Expect(response.Patches).To(HaveLen(2))
 					patches := jsonPatches(response.Patches)
 					Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "0")))
-					Expect(patches).To(ContainElement(addLabelPatch("spec-index", "0")))
 					// first created pod is bootstrapping,
 					// this pod was created second, so
 					// startup-ordinal should be 1
@@ -265,7 +261,7 @@ var _ = Describe("Add labels to qsts pods", func() {
 				It("keeps the previous startup-ordinal", func() {
 					Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-					Expect(response.Patches).To(HaveLen(3))
+					Expect(response.Patches).To(HaveLen(2))
 					patches := jsonPatches(response.Patches)
 					Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "0")))
 					// this is just a restart
@@ -287,10 +283,9 @@ var _ = Describe("Add labels to qsts pods", func() {
 			It("sets ordinal labels are correct", func() {
 				Expect(response.Allowed).To(BeTrue(), fmt.Sprintf("%v", response.Result))
 
-				Expect(response.Patches).To(HaveLen(3))
+				Expect(response.Patches).To(HaveLen(2))
 				patches := jsonPatches(response.Patches)
 				Expect(patches).To(ContainElement(addLabelPatch("pod-ordinal", "1")))
-				Expect(patches).To(ContainElement(addLabelPatch("spec-index", "1")))
 				Expect(patches).To(ContainElement(addLabelPatch("startup-ordinal", "0")))
 
 				Expect(response.AdmissionResponse.Allowed).To(BeTrue())


### PR DESCRIPTION
The spec-index label was unused and the calculation was wrong:

-	specIndex := names.SpecIndex(azIndex, podOrdinal)
+	specIndex := names.SpecIndex(azIndex+1, podOrdinal)

[#176906742](https://www.pivotaltracker.com/story/show/176906742)
