### PR TITLE
updated quarks-statefulset to pull images from private docker registry

### DIFF
--- a/deploy/helm/quarks-statefulset/templates/service-account-pull-secret.yaml
+++ b/deploy/helm/quarks-statefulset/templates/service-account-pull-secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.global.image.credentials }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: {{ template "quarks-statefulset.serviceAccountName" . }}-pull-secret
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ printf "{%q:{%q:{%q:%q,%q:%q,%q:%q}}}" "auths" .Values.global.image.credentials.servername "username" .Values.global.image.credentials.username "password" .Values.global.image.credentials.password "auth" (printf "%s:%s" .Values.global.image.credentials.username .Values.global.image.credentials.password | b64enc) | b64enc }}
+{{- end }}

--- a/deploy/helm/quarks-statefulset/templates/service-account.yaml
+++ b/deploy/helm/quarks-statefulset/templates/service-account.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: {{ template "quarks-statefulset.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.global.image.credentials }}
+imagePullSecrets:
+- name: {{ template "quarks-statefulset.serviceAccountName" . }}-pull-secret
+{{- end }}
 {{- end }}
 
 {{- if .Values.global.rbac.create }}

--- a/deploy/helm/quarks-statefulset/values.yaml
+++ b/deploy/helm/quarks-statefulset/values.yaml
@@ -57,6 +57,10 @@ global:
   image:
     # pullPolicy defines the policy used for pulling docker images.
     pullPolicy: IfNotPresent
+    credentials: ~
+      # username:
+      # password:
+      # servername:
   # monitoredID is a string that has to match the content of the 'monitored' label in each monitored namespace.
   # The monitoredID helper uses the release fullname, unless this is set.
   monitoredID:


### PR DESCRIPTION
This pull request raised because, unable to pull quarks-statefulset image from private docker registry. 
Below are the change details. 

1. Include global.image.credentials in values.yaml file for the images (quarks-stetefulset)
2. created service-account-pull-secret.yaml file for creating secret.
3. calling image credentials from secret (created in 2nd step) in service-account.yaml
