### PR TITLE
Change the naming of stateful sets with multi zones to match the real zone name

### DIFF
--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -256,7 +256,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 	// Update available-zone specified properties
 	if zoneName != "" {
 		// Override name prefix with zoneIndex
-		statefulSetNamePrefix = fmt.Sprintf("%s-z%d", qStatefulSet.GetName(), zoneIndex)
+		statefulSetNamePrefix = fmt.Sprintf("%s-%s", qStatefulSet.GetName(), zoneName)
 
 		labels[qstsv1a1.LabelAZName] = zoneName
 

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -269,6 +269,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 		statefulSet = r.updateAffinity(statefulSet, qStatefulSet.Spec.ZoneNodeLabel, zoneName)
 	}
 	labels[qstsv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
+	labels[qstsv1a1.LabelAZName] = zoneName
 	labels[qstsv1a1.LabelQStsName] = statefulSetNamePrefix
 
 	annotations[statefulset.AnnotationCanaryRolloutEnabled] = "true"

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
@@ -212,6 +212,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 
 				It("sets pod label for az index to 0 needed by service selector", func() {
 					Expect(ss.Spec.Template.GetLabels()).To(HaveKeyWithValue("quarks.cloudfoundry.org/az-index", "0"))
+					Expect(ss.Spec.Template.GetLabels()).To(HaveKeyWithValue("quarks.cloudfoundry.org/az-name", ""))
 				})
 
 			})

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
@@ -245,15 +245,15 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ0 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ1 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ2 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z3", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
 						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
@@ -274,7 +274,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 							Expect(podLabels).Should(HaveKeyWithValue(existingLabel, existingValue))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZIndex, strconv.Itoa(idx)))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZName, zones[idx]))
-							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-z%d", ess.Name, idx)))
+							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-%s", ess.Name, zones[idx])))
 
 							podAnnotations := ss.Spec.Template.GetAnnotations()
 							Expect(podAnnotations).Should(HaveKeyWithValue(existingAnnotation, existingValue))
@@ -351,15 +351,15 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ0 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ1 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ2 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z3", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
 						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
@@ -380,7 +380,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 							Expect(podLabels).Should(HaveKeyWithValue(existingLabel, existingValue))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZIndex, strconv.Itoa(idx)))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZName, zones[idx]))
-							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-z%d", ess.Name, idx)))
+							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-%s", ess.Name, zones[idx])))
 
 							podAnnotations := ss.Spec.Template.GetAnnotations()
 							Expect(podAnnotations).Should(HaveKeyWithValue(existingAnnotation, existingValue))


### PR DESCRIPTION
Update STS name to match the actual zone name not a zX (zone index)

Linked to this PR https://github.com/cloudfoundry-incubator/quarks-operator/pull/1303

change from zX in the statefulset name to zonename to make it clearer the name of the zone.

## Motivation and Context

We are trying to support multiple shards of cells. Because cells would all be named the same in all zones this caused us problems with dns and duplicate cell ids. This allows us to have multiple single zone clusters and fixes the problem of duplicate cell ids.

<!--- If it fixes an open issue or belongs to a story, please add a link here. -->

## Checklist:

Check item if necessary.

- [X] Review PRs of changed Quarks dependencies
- [ ] Update this PR after the release of Quarks dependencies
