### PR TITLE
Change to use AZ name instead of zone index enable topology spread co…

### DIFF
--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -256,7 +256,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 	// Update available-zone specified properties
 	if zoneName != "" {
 		// Override name prefix with zoneIndex
-		statefulSetNamePrefix = fmt.Sprintf("%s-z%d", qStatefulSet.GetName(), zoneIndex)
+		statefulSetNamePrefix = fmt.Sprintf("%s-%s-%d", qStatefulSet.GetName(), zoneName, zoneIndex)
 
 		labels[qstsv1a1.LabelAZName] = zoneName
 
@@ -269,6 +269,7 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 		statefulSet = r.updateAffinity(statefulSet, qStatefulSet.Spec.ZoneNodeLabel, zoneName)
 	}
 	labels[qstsv1a1.LabelAZIndex] = strconv.Itoa(zoneIndex)
+	labels[qstsv1a1.LabelAZName] = zoneName
 	labels[qstsv1a1.LabelQStsName] = statefulSetNamePrefix
 
 	annotations[statefulset.AnnotationCanaryRolloutEnabled] = "true"
@@ -287,6 +288,18 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 	statefulSet.SetAnnotations(util.UnionMaps(statefulSet.GetAnnotations(), annotations))
 
 	r.injectContainerEnv(&statefulSet.Spec.Template.Spec, zoneIndex, zoneName, qStatefulSet.Spec.Template.Spec.Replicas, qStatefulSet.Spec.InjectReplicasEnv)
+
+
+	statefulSet.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew: 1,
+			TopologyKey: corev1.LabelTopologyZone,
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
 	return statefulSet, nil
 }
 

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler.go
@@ -289,11 +289,10 @@ func (r *ReconcileQuarksStatefulSet) generateSingleStatefulSet(qStatefulSet *qst
 
 	r.injectContainerEnv(&statefulSet.Spec.Template.Spec, zoneIndex, zoneName, qStatefulSet.Spec.Template.Spec.Replicas, qStatefulSet.Spec.InjectReplicasEnv)
 
-
 	statefulSet.Spec.Template.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 		{
-			MaxSkew: 1,
-			TopologyKey: corev1.LabelTopologyZone,
+			MaxSkew:           1,
+			TopologyKey:       corev1.LabelTopologyZone,
 			WhenUnsatisfiable: corev1.ScheduleAnyway,
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: labels,

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
@@ -117,10 +117,10 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 										},
 										TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 											{
-												MaxSkew: 1,
-												TopologyKey: "ibm-cloud.kubernetes.io/zone",
+												MaxSkew:           1,
+												TopologyKey:       "ibm-cloud.kubernetes.io/zone",
 												WhenUnsatisfiable: "ScheduleAnyway",
-												LabelSelector: &metav1.LabelSelector{MatchLabels: selector},
+												LabelSelector:     &metav1.LabelSelector{MatchLabels: selector},
 											},
 										},
 									},

--- a/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
+++ b/pkg/kube/controllers/quarksstatefulset/quarksstatefulset_reconciler_test.go
@@ -80,6 +80,10 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 				existingLabel = "existing_label"
 				existingEnv = "existing_env"
 				existingValue = "existing_value"
+				selector := map[string]string{
+					"quarks.cloudfoundry.org/deployment-name":     "kubecf",
+					"quarks.cloudfoundry.org/instance-group-name": "api",
+				}
 
 				desiredQStatefulSet = &qstsv1a1.QuarksStatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
@@ -109,6 +113,14 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 														Value: existingValue,
 													},
 												},
+											},
+										},
+										TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+											{
+												MaxSkew: 1,
+												TopologyKey: "ibm-cloud.kubernetes.io/zone",
+												WhenUnsatisfiable: "ScheduleAnyway",
+												LabelSelector: &metav1.LabelSelector{MatchLabels: selector},
 											},
 										},
 									},
@@ -212,6 +224,11 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 
 				It("sets pod label for az index to 0 needed by service selector", func() {
 					Expect(ss.Spec.Template.GetLabels()).To(HaveKeyWithValue("quarks.cloudfoundry.org/az-index", "0"))
+					Expect(ss.Spec.Template.GetLabels()).To(HaveKeyWithValue("quarks.cloudfoundry.org/az-name", ""))
+				})
+
+				It("sets the TopologySpreadConstraints", func() {
+					Expect(ss.Spec.Template.Spec.TopologySpreadConstraints).Should(HaveLen(1))
 				})
 
 			})
@@ -245,15 +262,15 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ0 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1-0", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ1 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2-1", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ2 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z3-2", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
 						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
@@ -274,7 +291,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 							Expect(podLabels).Should(HaveKeyWithValue(existingLabel, existingValue))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZIndex, strconv.Itoa(idx)))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZName, zones[idx]))
-							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-z%d", ess.Name, idx)))
+							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-%s-%d", ess.Name, zones[idx], idx)))
 
 							podAnnotations := ss.Spec.Template.GetAnnotations()
 							Expect(podAnnotations).Should(HaveKeyWithValue(existingAnnotation, existingValue))
@@ -351,15 +368,15 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ0 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z0", Namespace: "default"}, ssZ0)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1-0", Namespace: "default"}, ssZ0)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ1 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z1", Namespace: "default"}, ssZ1)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2-1", Namespace: "default"}, ssZ1)
 						Expect(err).ToNot(HaveOccurred())
 
 						ssZ2 := &appsv1.StatefulSet{}
-						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z2", Namespace: "default"}, ssZ2)
+						err = client.Get(context.Background(), types.NamespacedName{Name: "foo-z3-2", Namespace: "default"}, ssZ2)
 						Expect(err).ToNot(HaveOccurred())
 
 						for idx, ss := range []*appsv1.StatefulSet{ssZ0, ssZ1, ssZ2} {
@@ -380,7 +397,7 @@ var _ = Describe("ReconcileQuarksStatefulSet", func() {
 							Expect(podLabels).Should(HaveKeyWithValue(existingLabel, existingValue))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZIndex, strconv.Itoa(idx)))
 							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelAZName, zones[idx]))
-							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-z%d", ess.Name, idx)))
+							Expect(podLabels).Should(HaveKeyWithValue(qstsv1a1.LabelQStsName, fmt.Sprintf("%s-%s-%d", ess.Name, zones[idx], idx)))
 
 							podAnnotations := ss.Spec.Template.GetAnnotations()
 							Expect(podAnnotations).Should(HaveKeyWithValue(existingAnnotation, existingValue))


### PR DESCRIPTION
Add use of topology spread constraints and change to use AZ name not index for multiple diego-cell cluster requirements.

Solves issues of having duplicate names of cells when having one cluster / AZ in our desired cluster topology.

Also allows a single stateful set to range over AZs using the topology spread contraints and does not require multi-az support to ensure spread across zones.
Check item if necessary.

- [X] Review PRs of changed Quarks dependencies
- [X] Update this PR after the release of Quarks dependencies

Related and must be deployed with PR https://github.com/cloudfoundry-incubator/quarks-operator/pull/1328
