### PR TITLE
Enable affinity configuration to schedule pod on specific nodes in cluster

### DIFF
--- a/deploy/helm/quarks-statefulset/README.md
+++ b/deploy/helm/quarks-statefulset/README.md
@@ -49,6 +49,7 @@ $ helm delete quarks-statefulset --purge
 | `global.operator.webhook.useServiceReference`     | If true, the webhook server is addressed using a service reference instead of the IP              | `true`                                         |
 | `serviceAccount.create`                           | If true, create a service account                                                      | `true`                                         |
 | `serviceAccount.name`                             | If not set and `create` is `true`, a name is generated using the fullname of the chart |                                                |
+| `affinity`                     |  Scheduling pod on specicifc nodes by adding labels to nodes                                      | `affinity`
 > **Note:**
 >
 > `global.operator.webhook.useServiceReference` will override `operator.webhook.endpoint` configuration

--- a/deploy/helm/quarks-statefulset/templates/operator.yaml
+++ b/deploy/helm/quarks-statefulset/templates/operator.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         name: quarks-statefulset
     spec:
+      {{- if .Values.affinity }}
+      affinity: {{ .Values.affinity | toJson }}
+      {{- end }}
       serviceAccountName: {{ template "quarks-statefulset.serviceAccountName" . }}
       containers:
         - name: quarks-statefulset

--- a/deploy/helm/quarks-statefulset/values.yaml
+++ b/deploy/helm/quarks-statefulset/values.yaml
@@ -69,5 +69,15 @@ global:
       # useServiceReference is a boolean to control the use of the
       # service reference in the webhook spec instead of a url.
       useServiceReference: true
-    # Scheduling pod on specicifc nodes by adding labels to nodes
+# Scheduling pod on specific nodes by adding labels to nodes
+# Example
+# affinity:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: NODE_LABEL_KEY
+#           operator: In
+#           values: 
+#           - NODE_LABEL_VALUE
 affinity: {}

--- a/deploy/helm/quarks-statefulset/values.yaml
+++ b/deploy/helm/quarks-statefulset/values.yaml
@@ -69,3 +69,5 @@ global:
       # useServiceReference is a boolean to control the use of the
       # service reference in the webhook spec instead of a url.
       useServiceReference: true
+    # Scheduling pod on specicifc nodes by adding labels to nodes
+affinity: {}

--- a/docs/crds/quarks_v1alpha1_quarksstatefulset_crd.yaml
+++ b/docs/crds/quarks_v1alpha1_quarksstatefulset_crd.yaml
@@ -1,3 +1,4 @@
+!REPLACEs
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/docs/crds/quarks_v1alpha1_quarksstatefulset_crd.yaml
+++ b/docs/crds/quarks_v1alpha1_quarksstatefulset_crd.yaml
@@ -1,90 +1,66 @@
-!REPLACEs
-apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
 metadata:
-  creationTimestamp: 2020-04-30T14:32:12Z
-  generation: 1
   name: quarksstatefulsets.quarks.cloudfoundry.org
-  resourceVersion: "2512198"
-  selfLink: /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/quarksstatefulsets.quarks.cloudfoundry.org
-  uid: 6a2bac4f-289d-4440-9a2a-c220725668e0
 spec:
-  conversion:
-    strategy: None
   group: quarks.cloudfoundry.org
   names:
+    plural: quarksstatefulsets
+    singular: quarksstatefulset
+    shortNames:
+      - qsts
     kind: QuarksStatefulSet
     listKind: QuarksStatefulSetList
-    plural: quarksstatefulsets
-    shortNames:
-    - qsts
-    singular: quarksstatefulset
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            activePassiveProbes:
-              description: Defines probes to determine active/passive component instances
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            template:
-              description: A template for a regular StatefulSet
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            updateOnConfigChange:
-              description: Indicate whether to update Pods in the StatefulSet when
-                an env value or mount changes
-              type: boolean
-            injectReplicasEnv:
-              description: Determines if the REPLICAS env var is injected into pod containers.
-                true by default
-              type: boolean
-            zoneNodeLabel:
-              description: Indicates the node label that a node locates
-              type: string
-            zones:
-              description: Indicates the availability zones that the QuarksStatefulSet
-                needs to span
-              items:
-                type: string
-              type: array
-          required:
-          - template
-          type: object
-        status:
-          properties:
-            lastReconcile:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: QuarksStatefulSet
-    listKind: QuarksStatefulSetList
-    plural: quarksstatefulsets
-    shortNames:
-    - qsts
-    singular: quarksstatefulset
-  conditions:
-  - lastTransitionTime: 2020-04-30T14:32:12Z
-    message: no conflicts found
-    reason: NoConflicts
-    status: "True"
-    type: NamesAccepted
-  - lastTransitionTime: null
-    message: the initial names have been accepted
-    reason: InitialNamesAccepted
-    status: "True"
-    type: Established
-  storedVersions:
-  - v1alpha1
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - template
+              properties:
+                activePassiveProbes:
+                  description: >-
+                    Defines probes to determine active/passive component
+                    instances
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                injectReplicasEnv:
+                  description: >-
+                    Determines if the REPLICAS env var is injected into pod
+                    containers.
+                  type: boolean
+                template:
+                  description: A template for a regular StatefulSet
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                updateOnConfigChange:
+                  description: >-
+                    Indicate whether to update Pods in the StatefulSet when an
+                    env value or mount changes
+                  type: boolean
+                zoneNodeLabel:
+                  description: Indicates the node label that a node locates
+                  type: string
+                zones:
+                  description: >-
+                    Indicates the availability zones that the QuarksStatefulSet
+                    needs to span
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                lastReconcile:
+                  type: string
+                ready:
+                  type: boolean
+  conversion:
+    strategy: None

--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,4 @@ require (
 )
 
 go 1.15
+replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,4 @@ require (
 )
 
 go 1.15
-replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.0.2
+replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.1.0

--- a/pkg/kube/apis/quarksstatefulset/v1alpha1/register.go
+++ b/pkg/kube/apis/quarksstatefulset/v1alpha1/register.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/kube/controllers/controllers_test.go
+++ b/pkg/kube/controllers/controllers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 
-	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/kube/controllers/quarksstatefulset/pod_webhook.go
+++ b/pkg/kube/controllers/quarksstatefulset/pod_webhook.go
@@ -4,7 +4,7 @@ import (
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"code.cloudfoundry.org/quarks-utils/pkg/config"

--- a/pkg/kube/controllers/statefulset/statefulset_webhook.go
+++ b/pkg/kube/controllers/statefulset/statefulset_webhook.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 


### PR DESCRIPTION
This PR helps to schedule pod on specific nodes in cluster & feature has been tested on openshift cluster. Here are the testing configurations & test results screen shots.

quarks-statefulset has been installed by helm by passing following affinity configuration values.

I. Label openshift cluster node

oc label node xx.xx.xx.249 cf-node-group=cf-nodes

II. Helm values as below

affinity:
nodeAffinity:
requiredDuringSchedulingIgnoredDuringExecution:
nodeSelectorTerms:
- matchExpressions:
- key: cf-node-group
operator: In
values:
- cf-nodes

III. Test Results, Pod is scheduled on labeled node "xx.xx.xx.249"

<img width="947" alt="quarks-statefulset" src="https://user-images.githubusercontent.com/81233158/126106659-612dfacd-eaa6-424e-ad16-da03a1a3dcb3.PNG">
